### PR TITLE
Normalise from path to allow symlink to a directory from inside that dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (from, to, type) {
   to = path.resolve(to)
   /* istanbul ignore else */
   if (!win) {
-    var target = from = path.relative(path.dirname(to), from)
+    var target = from = path.normalize(path.relative(path.dirname(to), from))
     if (target.length >= from.length) target = from
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -58,4 +58,13 @@ describe('fs-symlink', function () {
       assert.equal(__filename, resolved)
     })
   })
+
+  it('should symlink to itself from a child directory', function() {
+    var buildChildDir = path.join(build, 'build-child')
+    return link(build, buildChildDir).then(function () {
+      return fs.realpath(buildChildDir)
+    }).then(function (resolved) {
+      assert.equal(build, resolved)
+    })
+  })
 })


### PR DESCRIPTION
It is currently not possible to symlink to a directory from inside that
directory (e.g. symlink `/app/myfolder/folder` to `/app/myfolder`). This is because
we're using `path.dirname(to)` which will result in the same directory as the from
argument and the result of using `path.relative()` with two paths that are the same
is `''` - an empty string.

By using `path.normalize()` you get the correct result: `'.'`, the current directory