### PR TITLE
Updated mkdirp dependency to start from 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": "fs-utils/symlink",
   "dependencies": {
-    "mkdirp": "0",
+    "mkdirp": "^0.5.0",
     "mkdirp-then": "1",
     "mz": "^2.0.0"
   },


### PR DESCRIPTION
This dependency update fixes an edge-case where the symlinking will silently fail to work. The conditions which cause the symlinking to fail:

1. You use npm3 which has the flat `node_modules` directory structure
2. You have another plugin which specifies a dependency of `mkirp` of *< 0.5.0*
3. You don't pass the third param, the symlink "type", e.g. `junction`, `dir`, which in the node docs is stated to only really be required for Windows.
4. The directory one-level up from the symlinked directory already exists

For example, say I want to symlink the path `/path/to/symlink_dir` but the directories `path` and `to` already exist. This causes the callback which creates the symlink using `mkdirp-then` [not to fire](https://github.com/fs-utils/symlink/blob/6ce56a3a8b5201230abb28b71e427b7ffb915ec2/index.js#L30). It fails because the [callback passed to `mkdirp`](https://github.com/fs-utils/mkdirp-then/blob/master/index.js#L7) which resolves the `Promise` is [clobbered by some processing there](https://github.com/substack/node-mkdirp/blob/cf7d8bd9b8656d8edb48f0fd607798b6691f52c7/index.js#L7) if `mode` is not set. When `mode` is not set it rewrites the callback function to a no-op. Then the "making of the directory" fails with a `Error: EEXIST: file already exists, mkdir` error and the [no-op is called](https://github.com/substack/node-mkdirp/blob/cf7d8bd9b8656d8edb48f0fd607798b6691f52c7/index.js#L37), meaning the `mkdirp-then` `Promise` is never resolved.

The clobbering behaviour was resolved in a later version of `mkdirp` and this update means we always grab that version.